### PR TITLE
Fix spelling of classinfo.

### DIFF
--- a/src/dsymbol/builtin/symbols.d
+++ b/src/dsymbol/builtin/symbols.d
@@ -159,7 +159,7 @@ static this()
 	aggregateSymbols.insert(stringof_);
 	aggregateSymbols.insert(init);
 
-	classSymbols.insert(allocate!DSymbol(Mallocator.it, internString("classInfo"), CompletionKind.variableName));
+	classSymbols.insert(allocate!DSymbol(Mallocator.it, internString("classinfo"), CompletionKind.variableName));
 	classSymbols.insert(allocate!DSymbol(Mallocator.it, internString("tupleof"), CompletionKind.variableName));
 	classSymbols.insert(allocate!DSymbol(Mallocator.it, internString("__vptr"), CompletionKind.variableName));
 	classSymbols.insert(allocate!DSymbol(Mallocator.it, internString("__monitor"), CompletionKind.variableName));


### PR DESCRIPTION
The symbol classinfo was misspelled as classInfo.
See: http://dlang.org/property.html#classinfo

I noticed the DCD 0.7.0 branch was using dsymbol instead of declaring the symbols itself, so I just changed it in both places.