### PR TITLE
Avoid loading directories in the import paths

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -108,7 +108,7 @@ struct ModuleCache
 		{
 			foreach (fileName; dirEntries(path, "*.{d,di}", SpanMode.depth))
 			{
-				if (fileName.baseName.startsWith(".#"))
+				if (fileName.baseName.startsWith(".#") || !fileName.isFile)
 					continue;
 				cacheModule(fileName);
 			}


### PR DESCRIPTION
Linux configuration directories often end with the ".d" extension, so if
you have some in your project tree and it doesn't have a dedicated
"source" directory that acts as root, addImportPaths will think that
directory is a D source file, try to read it - and crash.