### PR TITLE
Make some of ModuleCache methods const-friendly

### DIFF
--- a/src/dsymbol/modulecache.d
+++ b/src/dsymbol/modulecache.d
@@ -311,12 +311,12 @@ struct ModuleCache
 		return alternatives.length > 0 ? internString(alternatives[0]) : istring(null);
 	}
 
-	auto getImportPaths()
+	auto getImportPaths() const
 	{
 		return importPaths[];
 	}
 
-	auto getAllSymbols()
+	auto getAllSymbols() const
 	{
 		return cache[];
 	}


### PR DESCRIPTION
Use case : I create module cache when conversion tool starts
and want to cast it to immutable so that it can be reused
between parallel worker threads (without ever modifying cache again).

I have considered marking some other ModuleCache methods as const/inout
too but that quickly has become a potentially intrusive API change so
sticking only to trivial ones I actually need for now.