### PR TITLE
Fix building dscanner with dub.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,7 +5,7 @@
 	"license": "BSL-1.0",
 	"authors": ["Brian Schott"],
 	"dependencies": {
-		"libdparse": "0.7.0-beta.1",
+		"libdparse": "~>0.7.0-beta.1",
 		"emsi_containers": "~>0.5.2"
 	}
 }


### PR DESCRIPTION
dscanner requires libdparse 0.7.0-beta.6 and dsymbol requires a different version causing the build to fail. Any dscanner version that doesn't also require verison 0.7.0-beta.1 doesn't build with dub, making them useless. Not sure if you want to just change the tag to a different commit rather than bumping up the version (the last 5 versions of dscanner will then remain broken).