### PR TITLE
ci(gh-actions): Fix typo in event name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,11 @@
-name: learn-github-actions
-on: [push, pull-request]
+name: CI
+
+on: [push, pull_request]
+
 jobs:
-  old-travis-tests:
+  main:
     name: Tests from travis-ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         libdparse-version: [min, max]


### PR DESCRIPTION
* `pull-request` should be `pull_request`
Also:
* Use `ubuntu-latest` instead of a hardcoded version
* Update the name of the pipeline